### PR TITLE
 Support build result pattern messesages

### DIFF
--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
@@ -173,7 +173,23 @@ public class ChatworkPublisher extends Publisher {
   }
 
   private String resolveMessage() {
-    return resolve(this.defaultMessage);
+    return resolve(getBuildMessage(build.getResult()));
+  }
+
+  private String getBuildMessage(Result result) {
+    if(result == Result.SUCCESS){
+      return getSuccessfulMessage();
+    } else if(result == Result.FAILURE){
+      return getFailureMessage();
+    } else if(result == Result.UNSTABLE){
+      return getUnstableMessage();
+    } else if(result == Result.NOT_BUILT){
+      return getNotBuiltMessage();
+    } else if(result == Result.ABORTED){
+      return getAbortedMessage();
+    }
+
+    return this.defaultMessage;
   }
 
   private String resolveRoomId() {

--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
@@ -24,21 +24,43 @@ public class ChatworkPublisher extends Publisher {
   private static final int MAX_COMMIT_MESSAGE_LENGTH = 50;
 
   private final String rid;
+
+  @Deprecated
   private final String defaultMessage;
 
-  private Boolean notifyOnSuccess;
-  private Boolean notifyOnFail;
+  private final String successfulMessage;
+  private final String failureMessage;
+  private final String unstableMessage;
+  private final String notBuiltMessage;
+  private final String abortedMessage;
+
+  private final Boolean notifyOnSuccess;
+  private final Boolean notifyOnFail;
+  private final Boolean notifyOnUnstable;
+  private final Boolean notifyOnNotBuilt;
+  private final Boolean notifyOnAborted;
+
   private transient AbstractBuild build;
   private transient BuildListener listener;
 
 
   // Fields in config.jelly must match the parameter names in the "DataBoundConstructor"
   @DataBoundConstructor
-  public ChatworkPublisher(String rid, String defaultMessage, Boolean notifyOnSuccess, Boolean notifyOnFail) {
+  public ChatworkPublisher(String rid, String defaultMessage, Boolean notifyOnSuccess, Boolean notifyOnFail, String unstableMessage, String notBuiltMessage, String abortedMessage, String successfulMessage, String failureMessage, Boolean notifyOnUnstable, Boolean notifyOnNotBuilt, Boolean notifyOnAborted) {
     this.rid = rid;
-    this.notifyOnSuccess = notifyOnSuccess;
-    this.notifyOnFail = notifyOnFail;
     this.defaultMessage = StringUtils.trimToEmpty(defaultMessage);
+
+    this.successfulMessage = StringUtils.trimToEmpty(successfulMessage);
+    this.failureMessage    = StringUtils.trimToEmpty(failureMessage);
+    this.unstableMessage   = StringUtils.trimToEmpty(unstableMessage);
+    this.notBuiltMessage   = StringUtils.trimToEmpty(notBuiltMessage);
+    this.abortedMessage    = StringUtils.trimToEmpty(abortedMessage);
+
+    this.notifyOnSuccess  = notifyOnSuccess;
+    this.notifyOnFail     = notifyOnFail;
+    this.notifyOnUnstable = notifyOnUnstable;
+    this.notifyOnNotBuilt = notifyOnNotBuilt;
+    this.notifyOnAborted  = notifyOnAborted;
   }
 
   /**
@@ -48,10 +70,31 @@ public class ChatworkPublisher extends Publisher {
     return rid;
   }
 
+  @Deprecated
   public String getDefaultMessage() {
     return defaultMessage;
   }
-  
+
+  public String getSuccessfulMessage() {
+    return successfulMessage;
+  }
+
+  public String getFailureMessage() {
+    return failureMessage;
+  }
+
+  public String getUnstableMessage() {
+    return unstableMessage;
+  }
+
+  public String getNotBuiltMessage() {
+    return notBuiltMessage;
+  }
+
+  public String getAbortedMessage() {
+    return abortedMessage;
+  }
+
   public Boolean getNotifyOnSuccess() {
     return notifyOnSuccess;
   }
@@ -60,15 +103,41 @@ public class ChatworkPublisher extends Publisher {
     return notifyOnFail;
   }
 
+  public Boolean getNotifyOnUnstable() {
+    return notifyOnUnstable;
+  }
+
+  public Boolean getNotifyOnNotBuilt() {
+    return notifyOnNotBuilt;
+  }
+
+  public Boolean getNotifyOnAborted() {
+    return notifyOnAborted;
+  }
+
   @Override
   public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
     this.build = build;
     this.listener = listener;
     
     if(this.build.getResult() == Result.SUCCESS && !this.notifyOnSuccess) {
+      println("skip post message because notifyOnSuccess is disabled");
       return true;
     }
     if(this.build.getResult() == Result.FAILURE && !this.notifyOnFail) {
+      println("skip post message because notifyOnFail is disabled");
+      return true;
+    }
+    if(this.build.getResult() == Result.UNSTABLE && !this.notifyOnUnstable) {
+      println("skip post message because notifyOnUnstable is disabled");
+      return true;
+    }
+    if(this.build.getResult() == Result.NOT_BUILT && !this.notifyOnNotBuilt) {
+      println("skip post message because notifyOnNotBuilt is disabled");
+      return true;
+    }
+    if(this.build.getResult() == Result.ABORTED && !this.notifyOnAborted) {
+      println("skip post message because notifyOnAborted is disabled");
       return true;
     }
 

--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
@@ -76,23 +76,29 @@ public class ChatworkPublisher extends Publisher {
   }
 
   public String getSuccessfulMessage() {
-    return successfulMessage;
+    return getMessageWithDefault(successfulMessage);
   }
 
   public String getFailureMessage() {
-    return failureMessage;
+    return getMessageWithDefault(failureMessage);
   }
 
   public String getUnstableMessage() {
-    return unstableMessage;
+    return getMessageWithDefault(unstableMessage);
   }
 
   public String getNotBuiltMessage() {
-    return notBuiltMessage;
+    return getMessageWithDefault(notBuiltMessage);
   }
 
   public String getAbortedMessage() {
-    return abortedMessage;
+    return getMessageWithDefault(abortedMessage);
+  }
+
+  private String getMessageWithDefault(String message){
+    // NOTE: backward compatibility
+    // if message is null, this plugin upgraded from <= v0.6.2
+    return message == null ? defaultMessage : message;
   }
 
   public Boolean getNotifyOnSuccess() {

--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherBuilder.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherBuilder.java
@@ -1,0 +1,84 @@
+package com.vexus2.jenkins.chatwork.jenkinschatworkplugin;
+
+public class ChatworkPublisherBuilder {
+  private String rid;
+
+  private String defaultMessage;
+
+  private String successfulMessage;
+  private String failureMessage;
+  private String unstableMessage;
+  private String notBuiltMessage;
+  private String abortedMessage;
+
+  private Boolean notifyOnSuccess = false;
+  private Boolean notifyOnFail = false;
+  private Boolean notifyOnUnstable = false;
+  private Boolean notifyOnNotBuilt = false;
+  private Boolean notifyOnAborted = false;
+
+  public ChatworkPublisherBuilder rid(String value){
+    rid = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder defaultMessage(String value){
+    defaultMessage = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder successfulMessage(String value){
+    successfulMessage = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder failureMessage(String value){
+    failureMessage = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder unstableMessage(String value){
+    unstableMessage = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder notBuiltMessage(String value){
+    notBuiltMessage = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder abortedMessage(String value){
+    abortedMessage = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder notifyOnSuccess(Boolean value){
+    notifyOnSuccess = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder notifyOnFail(Boolean value){
+    notifyOnFail = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder notifyOnUnstable(Boolean value){
+    notifyOnUnstable = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder notifyOnNotBuilt(Boolean value){
+    notifyOnSuccess = value;
+    return this;
+  }
+
+  public ChatworkPublisherBuilder notifyOnAborted(Boolean value){
+    notifyOnAborted = value;
+    return this;
+  }
+
+  public ChatworkPublisher build(){
+    return new ChatworkPublisher(rid, defaultMessage, notifyOnSuccess, notifyOnFail, unstableMessage, notBuiltMessage, abortedMessage, successfulMessage, failureMessage, notifyOnUnstable, notifyOnNotBuilt, notifyOnAborted);
+  }
+
+}

--- a/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/config.jelly
+++ b/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/config.jelly
@@ -1,28 +1,15 @@
-<j:jelly xmlns:j="jelly:core"
-         xmlns:st="jelly:stapler"
-         xmlns:d="jelly:define"
-         xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson"
-         xmlns:f="/lib/form">
-    <f:entry
-            title="Chatwork Room ID"
-            field="rid"
-            description="Set Room ID you want to notice">
-        <f:textbox/>
-    </f:entry>
-    <f:entry
-            title="Default message"
-            field="defaultMessage">
-        <f:textarea/>
-    </f:entry>
-    <f:entry
-            title="notify on build success"
-            field="notifyOnSuccess">
-        <f:checkbox/>
-    </f:entry>
-    <f:entry
-            title="notify on build fail"
-            field="notifyOnFail">
-        <f:checkbox/>
-    </f:entry>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+  xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="Chatwork Room ID" field="rid" description="Set Room ID you want to notice">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="Default message" field="defaultMessage">
+    <f:textarea/>
+  </f:entry>
+  <f:entry title="notify on build success" field="notifyOnSuccess">
+    <f:checkbox/>
+  </f:entry>
+  <f:entry title="notify on build fail" field="notifyOnFail">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/config.jelly
+++ b/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/config.jelly
@@ -3,13 +3,39 @@
   <f:entry title="Chatwork Room ID" field="rid" description="Set Room ID you want to notice">
     <f:textbox/>
   </f:entry>
-  <f:entry title="Default message" field="defaultMessage">
+
+  <f:entry title="Successful message" field="successfulMessage">
     <f:textarea/>
   </f:entry>
   <f:entry title="notify on build success" field="notifyOnSuccess">
     <f:checkbox/>
   </f:entry>
-  <f:entry title="notify on build fail" field="notifyOnFail">
+
+  <f:entry title="Failure message" field="failureMessage">
+    <f:textarea/>
+  </f:entry>
+  <f:entry title="notify on build failure" field="notifyOnFail">
+    <f:checkbox/>
+  </f:entry>
+
+  <f:entry title="Unstable message" field="unstableMessage">
+    <f:textarea/>
+  </f:entry>
+  <f:entry title="notify on build unstable" field="notifyOnUnstable">
+    <f:checkbox/>
+  </f:entry>
+
+  <f:entry title="Not built message" field="notBuiltMessage">
+    <f:textarea/>
+  </f:entry>
+  <f:entry title="notify on build not built" field="notifyOnNotBuilt">
+    <f:checkbox/>
+  </f:entry>
+
+  <f:entry title="Aborted message" field="abortedMessage">
+    <f:textarea/>
+  </f:entry>
+  <f:entry title="notify on build aborted" field="notifyOnAborted">
     <f:checkbox/>
   </f:entry>
 </j:jelly>

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherSpec.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherSpec.groovy
@@ -1,26 +1,24 @@
 package com.vexus2.jenkins.chatwork.jenkinschatworkplugin
-
 import hudson.EnvVars
 import hudson.model.AbstractBuild
 import hudson.model.Result
 import hudson.model.TaskListener
-import org.junit.Before
-import org.junit.Test
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
+import spock.lang.Specification
 
-import static org.mockito.Matchers.any
+import static org.mockito.Matchers.*
 import static org.mockito.Mockito.*
 
 @RunWith(Enclosed)
-class ChatworkPublisherTest {
+class ChatworkPublisherSpec {
   static String readFixture(String fileName){
-    ChatworkPublisherTest.class.getClassLoader().getResource("com/vexus2/jenkins/chatwork/jenkinschatworkplugin/${fileName}").getText()
+    ChatworkPublisherSpec.class.getClassLoader().getResource("com/vexus2/jenkins/chatwork/jenkinschatworkplugin/${fileName}").getText()
   }
 
-  static class analyzePayload {
-    @Test
-    void "should create PullRequest message"(){
+  static class analyzePayload extends Specification {
+    def "should create PullRequest message"() {
+      when:
       // via. https://developer.github.com/v3/pulls/#get-a-single-pull-request
       String parameterDefinition = readFixture("payload_PullRequest.json")
 
@@ -31,11 +29,12 @@ new-feature
 https://github.com/octocat/Hello-World/pull/1
 """.trim()
 
-      assert ChatworkPublisher.analyzePayload(parameterDefinition) == expected
+      then:
+      ChatworkPublisher.analyzePayload(parameterDefinition) == expected
     }
 
-    @Test
-    void "should create compare message"(){
+    def "should create compare message"() {
+      when:
       String parameterDefinition = readFixture("payload_compare.json")
 
       String expected = """
@@ -46,21 +45,23 @@ octocat pushed into Hello-World,
 https://github.com/octocat/Hello-World/compare/master...topic
 """.trim()
 
-      assert ChatworkPublisher.analyzePayload(parameterDefinition) == expected
+      then:
+      ChatworkPublisher.analyzePayload(parameterDefinition) == expected
     }
 
-    @Test
-    void "When neither PullRequest nor compare, should return null"(){
+    def "When neither PullRequest nor compare, should return null"(){
+      when:
       String parameterDefinition = readFixture("payload_empty.json")
-      assert ChatworkPublisher.analyzePayload(parameterDefinition) == null
+
+      then:
+      ChatworkPublisher.analyzePayload(parameterDefinition) == null
     }
   }
 
-  static class resolveMessage {
+  static class resolveMessage extends Specification {
     ChatworkPublisher publisher
 
-    @Before
-    void setUp(){
+    def setup(){
       // via. https://gist.github.com/gjtorikian/5171861
       String payload = readFixture("payload_webhook.json")
       publisher = new ChatworkPublisherBuilder().rid("00000000").
@@ -74,8 +75,8 @@ https://github.com/octocat/Hello-World/compare/master...topic
       publisher.build = mockBuild
     }
 
-    @Test
-    void "When contains payload param, should resolve payload"(){
+    def "When contains payload param, should resolve payload"(){
+      when:
       String excepted = """
 Garen Torikian pushed into testing,
 - Test
@@ -85,7 +86,8 @@ Garen Torikian pushed into testing,
 https://github.com/octokitty/testing/compare/17c497ccc7cc...1481a2de7b2a
 """.trim()
 
-      assert publisher.resolveMessage() == excepted
+      then:
+      publisher.resolveMessage() == excepted
     }
   }
 }

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherSpec.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherSpec.groovy
@@ -6,6 +6,7 @@ import hudson.model.TaskListener
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static org.mockito.Matchers.*
 import static org.mockito.Mockito.*
@@ -65,7 +66,7 @@ https://github.com/octocat/Hello-World/compare/master...topic
       // via. https://gist.github.com/gjtorikian/5171861
       String payload = readFixture("payload_webhook.json")
       publisher = new ChatworkPublisherBuilder().rid("00000000").
-          defaultMessage('$PAYLOAD_SUMMARY').notifyOnSuccess(true).notifyOnFail(true).build()
+          successfulMessage('$PAYLOAD_SUMMARY').notifyOnSuccess(true).notifyOnFail(true).build()
 
       AbstractBuild mockBuild = mock(AbstractBuild)
       when(mockBuild.getBuildVariables()).thenReturn(['payload': payload])
@@ -88,6 +89,31 @@ https://github.com/octokitty/testing/compare/17c497ccc7cc...1481a2de7b2a
 
       then:
       publisher.resolveMessage() == excepted
+    }
+  }
+
+  static class getBuildMessage extends Specification {
+    @Unroll
+    def "should return message"(){
+      setup:
+      ChatworkPublisher publisher = new ChatworkPublisherBuilder().
+          successfulMessage("successfulMessage").
+          failureMessage("failureMessage").
+          unstableMessage("unstableMessage").
+          notBuiltMessage("notBuiltMessage").
+          abortedMessage("abortedMessage").
+          build()
+
+      expect:
+      publisher.getBuildMessage(result) == expected
+
+      where:
+      result           | expected
+      Result.SUCCESS   | "successfulMessage"
+      Result.FAILURE   | "failureMessage"
+      Result.UNSTABLE  | "unstableMessage"
+      Result.NOT_BUILT | "notBuiltMessage"
+      Result.ABORTED   | "abortedMessage"
     }
   }
 }

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherTest.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherTest.groovy
@@ -63,12 +63,8 @@ https://github.com/octocat/Hello-World/compare/master...topic
     void setUp(){
       // via. https://gist.github.com/gjtorikian/5171861
       String payload = readFixture("payload_webhook.json")
-
-      String roomId = "00000000"
-      String defaultMessage = '$PAYLOAD_SUMMARY'
-      boolean notifyOnSuccess = true
-      boolean notifyOnFail = true
-      publisher = new ChatworkPublisher(roomId, defaultMessage, notifyOnSuccess, notifyOnFail)
+      publisher = new ChatworkPublisherBuilder().rid("00000000").
+          defaultMessage('$PAYLOAD_SUMMARY').notifyOnSuccess(true).notifyOnFail(true).build()
 
       AbstractBuild mockBuild = mock(AbstractBuild)
       when(mockBuild.getBuildVariables()).thenReturn(['payload': payload])


### PR DESCRIPTION
# Before

single message
![before](https://cloud.githubusercontent.com/assets/608755/6376287/5281a438-bd60-11e4-9d52-7a8e2c10e4aa.png)
# After

successfulMessage, failureMessage, unstableMessage, notBuiltMessage, notifyOnAborted

![after](https://cloud.githubusercontent.com/assets/608755/6376360/a7729e0c-bd60-11e4-9abb-24cbdfd59bf5.png)
## backward compatibility

If upgrade from <= v0.6.2, `xxxxMessages` is initialized by `defaultMessage`
ref. 91ad31aa8c50b90a8cedf51348c8195a08999dc7
