### PR TITLE
Add global messages

### DIFF
--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
@@ -302,6 +302,36 @@ public class ChatworkPublisher extends Publisher {
     public String getProxyport() {
       return proxyport;
     }
+    
+    private String globalSuccessfulMessage;
+
+    private String globalFailureMessage;
+
+    private String globalUnstableMessage;
+
+    private String globalNotBuiltMessage;
+
+    private String globalAbortedMessage;
+
+    public String getGlobalSuccessfulMessage() {
+      return globalSuccessfulMessage;
+    }
+
+    public String getGlobalFailureMessage() {
+      return globalFailureMessage;
+    }
+
+    public String getGlobalUnstableMessage() {
+      return globalUnstableMessage;
+    }
+
+    public String getGlobalNotBuiltMessage() {
+      return globalNotBuiltMessage;
+    }
+
+    public String getGlobalAbortedMessage() {
+      return globalAbortedMessage;
+    }
 
     public DescriptorImpl() {
       load();
@@ -320,6 +350,13 @@ public class ChatworkPublisher extends Publisher {
       apikey = formData.getString("apikey");
       proxysv = formData.getString("proxysv");
       proxyport = formData.getString("proxyport");
+
+      globalSuccessfulMessage = formData.getString("globalSuccessfulMessage");
+      globalFailureMessage    = formData.getString("globalFailureMessage");
+      globalUnstableMessage   = formData.getString("globalUnstableMessage");
+      globalNotBuiltMessage   = formData.getString("globalNotBuiltMessage");
+      globalAbortedMessage    = formData.getString("globalAbortedMessage");
+
       save();
       return super.configure(req, formData);
     }

--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
@@ -360,5 +360,20 @@ public class ChatworkPublisher extends Publisher {
       save();
       return super.configure(req, formData);
     }
+    
+    public String getGlobalResultMessage(Result result){
+      if(result == Result.SUCCESS){
+        return getGlobalSuccessfulMessage();
+      } else if(result == Result.FAILURE){
+        return getGlobalFailureMessage();
+      } else if(result == Result.UNSTABLE){
+        return getGlobalUnstableMessage();
+      } else if(result == Result.NOT_BUILT){
+        return getGlobalNotBuiltMessage();
+      } else if(result == Result.ABORTED){
+        return getGlobalAbortedMessage();
+      }
+      return "";
+    }
   }
 }

--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
@@ -173,7 +173,15 @@ public class ChatworkPublisher extends Publisher {
   }
 
   private String resolveMessage() {
-    return resolve(getJobResultMessage(build.getResult()));
+    String jobResultMessage = getJobResultMessage(build.getResult());
+    
+    if(StringUtils.isBlank(jobResultMessage)){
+      String globalResultMessage = getDescriptor().getGlobalResultMessage(build.getResult());
+      return resolve(globalResultMessage);
+
+    } else{
+      return resolve(jobResultMessage);
+    }
   }
 
   private String getJobResultMessage(Result result) {

--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
@@ -173,10 +173,10 @@ public class ChatworkPublisher extends Publisher {
   }
 
   private String resolveMessage() {
-    return resolve(getBuildMessage(build.getResult()));
+    return resolve(getJobResultMessage(build.getResult()));
   }
 
-  private String getBuildMessage(Result result) {
+  private String getJobResultMessage(Result result) {
     if(result == Result.SUCCESS){
       return getSuccessfulMessage();
     } else if(result == Result.FAILURE){

--- a/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/config.jelly
+++ b/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/config.jelly
@@ -4,35 +4,40 @@
     <f:textbox/>
   </f:entry>
 
-  <f:entry title="Successful message" field="successfulMessage">
+  <f:entry title="Successful message" field="successfulMessage"
+      description="If 'Successful message' is blank, used 'Global Successful message'">
     <f:textarea/>
   </f:entry>
   <f:entry title="notify on build success" field="notifyOnSuccess">
     <f:checkbox/>
   </f:entry>
 
-  <f:entry title="Failure message" field="failureMessage">
+  <f:entry title="Failure message" field="failureMessage"
+      description="If 'Failure message' is blank, used 'Global Failure message'">
     <f:textarea/>
   </f:entry>
   <f:entry title="notify on build failure" field="notifyOnFail">
     <f:checkbox/>
   </f:entry>
 
-  <f:entry title="Unstable message" field="unstableMessage">
+  <f:entry title="Unstable message" field="unstableMessage"
+      description="If 'Unstable message' is blank, used 'Global Unstable message'">
     <f:textarea/>
   </f:entry>
   <f:entry title="notify on build unstable" field="notifyOnUnstable">
     <f:checkbox/>
   </f:entry>
 
-  <f:entry title="Not built message" field="notBuiltMessage">
+  <f:entry title="Not built message" field="notBuiltMessage"
+      description="If 'Not built message' is blank, used 'Global Not built message'">
     <f:textarea/>
   </f:entry>
   <f:entry title="notify on build not built" field="notifyOnNotBuilt">
     <f:checkbox/>
   </f:entry>
 
-  <f:entry title="Aborted message" field="abortedMessage">
+  <f:entry title="Aborted message" field="abortedMessage"
+      description="If 'Aborted message' is blank, used 'Global Aborted message'">
     <f:textarea/>
   </f:entry>
   <f:entry title="notify on build aborted" field="notifyOnAborted">

--- a/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/global.jelly
+++ b/src/main/resources/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher/global.jelly
@@ -25,6 +25,21 @@
       description="Set your Proxy port">
       <f:textbox />
     </f:entry>
-      <!--TODO: relation GitHub User <-> Chatwork ID-->
+
+    <f:entry title="Global Successful message" field="globalSuccessfulMessage">
+      <f:textarea/>
+    </f:entry>
+    <f:entry title="Global Failure message" field="globalFailureMessage">
+      <f:textarea/>
+    </f:entry>
+    <f:entry title="Global Unstable message" field="globalUnstableMessage">
+      <f:textarea/>
+    </f:entry>
+    <f:entry title="Global Not built message" field="globalNotBuiltMessage">
+      <f:textarea/>
+    </f:entry>
+    <f:entry title="Global Aborted message" field="globalAbortedMessage">
+      <f:textarea/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherSpec.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherSpec.groovy
@@ -92,7 +92,7 @@ https://github.com/octokitty/testing/compare/17c497ccc7cc...1481a2de7b2a
     }
   }
 
-  static class getBuildMessage extends Specification {
+  static class getJobResultMessage extends Specification {
     @Unroll
     def "should return message"(){
       setup:
@@ -105,7 +105,7 @@ https://github.com/octokitty/testing/compare/17c497ccc7cc...1481a2de7b2a
           build()
 
       expect:
-      publisher.getBuildMessage(result) == expected
+      publisher.getJobResultMessage(result) == expected
 
       where:
       result           | expected


### PR DESCRIPTION
if specified job message is blank, use global message.
## Global setting

Add global message settings

![2015-02-27 22 17 35](https://cloud.githubusercontent.com/assets/608755/6413092/028497ea-becf-11e4-8272-e5b1f6565709.png)
## Job setting

Add descriptions

![2015-02-27 22 16 57](https://cloud.githubusercontent.com/assets/608755/6413094/04531b96-becf-11e4-93f0-43b7c3dd39ba.png)
## Example

| successfulMessage | globalSuccessfulMessage | result |
| --- | --- | --- |
| `"job setting message"` | `"global setting message"` | `"job setting message"` |
| `(blank)` | `"global setting message"` | `"global setting message"` |
