### PR TITLE
If proxySv and proxyPort are empty or invalid, don't use proxy

### DIFF
--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClient.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClient.java
@@ -37,11 +37,12 @@ public class ChatworkClient {
     URL obj = new URL(url);
     HttpsURLConnection con;
 
-    if (!isEnabledProxy()) {
-      con = (HttpsURLConnection) obj.openConnection();
-    } else {
+    if (isEnabledProxy()) {
       Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(this.proxySv, Integer.parseInt(this.proxyPort)));
       con = (HttpsURLConnection) obj.openConnection(proxy);
+
+    } else {
+      con = (HttpsURLConnection) obj.openConnection();
     }
 
     con.setRequestMethod("POST");

--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClient.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClient.java
@@ -73,6 +73,18 @@ public class ChatworkClient {
   }
 
   public boolean isEnabledProxy(){
-    return !StringUtils.equals(this.proxySv, "NOPROXY");
+    if(StringUtils.isEmpty(proxySv) || StringUtils.isEmpty(proxyPort) || StringUtils.equals(proxySv, "NOPROXY")){
+      return false;
+    }
+
+    try {
+      Integer.parseInt(proxyPort);
+
+    } catch (NumberFormatException e){
+      // proxyPort is not number
+      return false;
+    }
+
+    return true;
   }
 }

--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClient.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClient.java
@@ -37,7 +37,7 @@ public class ChatworkClient {
     URL obj = new URL(url);
     HttpsURLConnection con;
 
-    if (StringUtils.equals(this.proxySv, "NOPROXY")) {
+    if (!isEnabledProxy()) {
       con = (HttpsURLConnection) obj.openConnection();
     } else {
       Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(this.proxySv, Integer.parseInt(this.proxyPort)));
@@ -70,5 +70,9 @@ public class ChatworkClient {
     }
 
     return true;
+  }
+
+  public boolean isEnabledProxy(){
+    return !StringUtils.equals(this.proxySv, "NOPROXY");
   }
 }

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClientSpec.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClientSpec.groovy
@@ -5,36 +5,41 @@ import co.freeside.betamax.MatchRule
 import co.freeside.betamax.Recorder
 import co.freeside.betamax.TapeMode
 import org.junit.Rule
+import org.junit.experimental.runners.Enclosed
+import org.junit.runner.RunWith
 import spock.lang.Ignore
 import spock.lang.Specification
 
-class ChatworkClientSpec extends Specification {
-  static final String TAPE_NAME = "ChatWork_v1_POST_rooms_messages"
+@RunWith(Enclosed)
+class ChatworkClientSpec{
+  static class sendMessage extends Specification {
+    static final String TAPE_NAME = "ChatWork_v1_POST_rooms_messages"
 
-  ChatworkClient client
+    ChatworkClient client
 
-  @Rule
-  Recorder recorder = new Recorder()
+    @Rule
+    Recorder recorder = new Recorder()
 
-  def setup(){
-    String apiKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    String proxySv = "NOPROXY"
-    String proxyPort = "80"
-    String channelId = "00000000"
-    client = new ChatworkClient(apiKey, proxySv, proxyPort, channelId)
-  }
+    def setup(){
+      String apiKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      String proxySv = "NOPROXY"
+      String proxyPort = "80"
+      String channelId = "00000000"
+      client = new ChatworkClient(apiKey, proxySv, proxyPort, channelId)
+    }
 
-  @Betamax(tape=ChatworkClientSpec.TAPE_NAME, mode = TapeMode.READ_ONLY, match = [MatchRule.host, MatchRule.path])
-  def "sendMessage should send message"(){
-    expect:
-    client.sendMessage("testMessage") == true
-  }
+    @Betamax(tape=ChatworkClientSpec.sendMessage.TAPE_NAME, mode = TapeMode.READ_ONLY, match = [MatchRule.host, MatchRule.path])
+    def "sendMessage should send message"(){
+      expect:
+      client.sendMessage("testMessage") == true
+    }
 
-  @Ignore
-  @Betamax(tape=ChatworkClientSpec.TAPE_NAME, mode = TapeMode.WRITE_ONLY, match = [MatchRule.host, MatchRule.path])
-  def "call ChatWork API and save response to src/test/resources/betamax/tapes/ChatWork_v1_POST_rooms_messages.yaml"(){
-    expect:
-    // TODO: If you want to use, set your actual apiKey and roomId
-    client.sendMessage("testMessage")
+    @Ignore
+    @Betamax(tape=ChatworkClientSpec.sendMessage.TAPE_NAME, mode = TapeMode.WRITE_ONLY, match = [MatchRule.host, MatchRule.path])
+    def "call ChatWork API and save response to src/test/resources/betamax/tapes/ChatWork_v1_POST_rooms_messages.yaml"(){
+      expect:
+      // TODO: If you want to use, set your actual apiKey and roomId
+      client.sendMessage("testMessage")
+    }
   }
 }

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClientSpec.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClientSpec.groovy
@@ -9,6 +9,7 @@ import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import spock.lang.Ignore
 import spock.lang.Specification
+import spock.lang.Unroll
 
 @RunWith(Enclosed)
 class ChatworkClientSpec{
@@ -40,6 +41,28 @@ class ChatworkClientSpec{
       expect:
       // TODO: If you want to use, set your actual apiKey and roomId
       client.sendMessage("testMessage")
+    }
+  }
+
+  static class enabledProxy extends Specification {
+    @Unroll
+    def "proxySv=#proxySv, proxyPort=#proxyPort: isEnabledProxy() == #expected"(){
+      setup:
+      ChatworkClient client = new ChatworkClient("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", proxySv, proxyPort, "00000000")
+
+      expect:
+      client.isEnabledProxy() == expected
+
+      where:
+      proxySv     | proxyPort || expected
+      "NOPROXY"   | ""        || false
+      "NOPROXY"   | "80"      || false
+      "localhost" | "80"      || true
+      "localhost" | ""        || true
+      ""          | "80"      || true
+      ""          | ""        || true
+      null        | "80"      || true
+      null        | ""        || true
     }
   }
 }

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClientSpec.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkClientSpec.groovy
@@ -58,11 +58,12 @@ class ChatworkClientSpec{
       "NOPROXY"   | ""        || false
       "NOPROXY"   | "80"      || false
       "localhost" | "80"      || true
-      "localhost" | ""        || true
-      ""          | "80"      || true
-      ""          | ""        || true
-      null        | "80"      || true
-      null        | ""        || true
+      "localhost" | "str"     || false
+      "localhost" | ""        || false
+      ""          | "80"      || false
+      ""          | ""        || false
+      null        | "80"      || false
+      null        | ""        || false
     }
   }
 }


### PR DESCRIPTION
#17 #16

| proxySv | proxyPort | Use proxy? (0.x -> 1.0.0+) |
| --- | --- | --- |
| `NOPROXY` | (empty) | x ->   x |
| `NOPROXY` | `80` | x   ->   x |
| `localhost` | `80` | o  ->  o |
| `localhost` | (invalid number) | o ->   x **(CHANGED!)** |
| `localhost` | (empty) | o  ->   x **(CHANGED!)** |
| (empty) | `80` | o  ->   x **(CHANGED!)** |
| (empty) | (empty) | o  ->   x **(CHANGED!)** |
