### PR TITLE
fix bug causing null value exception

### DIFF
--- a/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
+++ b/src/main/java/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisher.java
@@ -135,7 +135,7 @@ public class ChatworkPublisher extends Publisher {
   public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
     this.build = build;
     this.listener = listener;
-    
+
     if(this.build.getResult() == Result.SUCCESS && !this.notifyOnSuccess) {
       println("skip post message because notifyOnSuccess is disabled");
       return true;
@@ -184,7 +184,7 @@ public class ChatworkPublisher extends Publisher {
 
   private String resolveMessage() {
     String jobResultMessage = getJobResultMessage(build.getResult());
-    
+
     if(StringUtils.isBlank(jobResultMessage)){
       String globalResultMessage = getDescriptor().getGlobalResultMessage(build.getResult());
       return resolve(globalResultMessage);
@@ -279,7 +279,7 @@ public class ChatworkPublisher extends Publisher {
       return message.toString();
     }
 
-    return null;
+    return "";
   }
 
   @Override
@@ -321,7 +321,7 @@ public class ChatworkPublisher extends Publisher {
     public String getProxyport() {
       return proxyport;
     }
-    
+
     private String globalSuccessMessage;
 
     private String globalFailureMessage;
@@ -379,7 +379,7 @@ public class ChatworkPublisher extends Publisher {
       save();
       return super.configure(req, formData);
     }
-    
+
     public String getGlobalResultMessage(Result result){
       if(result == Result.SUCCESS){
         return getGlobalSuccessMessage();

--- a/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherSpec.groovy
+++ b/src/test/groovy/com/vexus2/jenkins/chatwork/jenkinschatworkplugin/ChatworkPublisherSpec.groovy
@@ -50,12 +50,12 @@ https://github.com/octocat/Hello-World/compare/master...topic
       ChatworkPublisher.analyzePayload(parameterDefinition) == expected
     }
 
-    def "When neither PullRequest nor compare, should return null"(){
+    def "When neither PullRequest nor compare, should return empty string"(){
       when:
       String parameterDefinition = readFixture("payload_empty.json")
 
       then:
-      ChatworkPublisher.analyzePayload(parameterDefinition) == null
+      ChatworkPublisher.analyzePayload(parameterDefinition) == ""
     }
   }
 


### PR DESCRIPTION
If environment variable contains the payload, can be assigned null value in `PAYLOAD_SUMMARY`. In this case, environment variable is not referenced in the chatwork's message for The following exceptions.

in BuildVariableUtil.java(This exception is suppressed for try-catch in fact)
`java.lang.IllegalArgumentException: Null value not allowed as an environment variable: PAYLOAD_SUMMARY`

Therefore, instead of null value an empty string be assigned in `PAYLOAD_SUMMARY` by this pull request.
